### PR TITLE
Define encoding for "load_ranking" and "load_qrels"

### DIFF
--- a/src/core_metrics.py
+++ b/src/core_metrics.py
@@ -229,7 +229,7 @@ def compute_f1(a_gold, a_pred):
 #
 
 def load_qrels(path):
-    with open(path, 'r') as file:
+    with open(path, 'r', encoding="utf8") as file:
         qids_to_relevant_passageids = {}
         for line in file:
             try:
@@ -245,7 +245,7 @@ def load_qrels(path):
 
 
 def load_ranking(path, qrels=None):
-    with open(path, 'r') as file:
+    with open(path, 'r', encoding="utf8") as file:
         qid_to_ranked_candidate_passages = {}
         for line in file:
             try:


### PR DESCRIPTION
The methods "load_ranking" and "load_qrels" in core_metrics.py are calling commands to open files. 
I had errors with it because the encoding wasn't specified.

In data_loading.py, the open commands use "utf-8" everywhere, and I believe this is also the encoding of all the provided data files and should work on all operating systems.
So I added "utf-8" encoding to "load_ranking" and "load_qrels" as well.

Sincerely,
Richard Binder